### PR TITLE
Add Support for Default TTLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+__ttl*

--- a/README.md
+++ b/README.md
@@ -54,6 +54,38 @@ db = ttl(db, { checkFrequency: 1000 })
 
 Of course, a scan takes some resources, particularly on a data store that makes heavy use of TTLs. If you don't require high accuracy for actual deletions then you can increase the `'checkFrequency'`. Note though that a scan only involves invoking a LevelUP ReadStream that returns *only the entries due to expire*, so it doesn't have to manually check through all entries with a TTL. As usual, it's best to not do too much tuning until you have you have something worth tuning!
 
+You can also specify a defaultTTL that will be applied to all keys. By default it is disabled. You can tune it by passing `'defaultTTL'` option to the `ttl()` initializer. 
+
+```js
+var db = level('/tmp/foo.db')
+// Expire all by default at 1 hour
+db = ttl(db, { defaultTTL: 60 * 60 * 1000 })
+
+/* .. */
+```
+
+If you specify a TTL on a `put` or a `batch` that will be used instead of the defaultTTL.
+
+```js
+var db = level('/tmp/foo.db')
+// Expire all by default at 1 hour
+db = ttl(db, { defaultTTL: 60 * 60 * 1000 })
+
+// 30 Second Timeout Used instead of the defaulTTL of 1 hour
+db.put('foo', 'bar', { ttl: 30 * 1000 }, function(err) {})
+```
+
+If you want to disable the defaultTTL you simply pass a zero (0) when performing the `put` or `batch`
+
+```js
+var db = level('/tmp/foo.db')
+// Expire all by default at 1 hour
+db = ttl(db, { defaultTTL: 60 * 60 * 1000 })
+
+// This entry will not get get a TTL.
+db.put('foo', 'bar', { ttl: 0 }, function(err) {})
+```
+
 ### Shutting down
 
 **Level TTL** uses a timer to regularly check for expiring entries (don't worry, the whole data store isn't scanned, it's very efficient!). The `db.close()` method is automatically wired to stop the timer but there is also a more explicit <b><code>db.stop()</code></b> method that will stop the timer and not pass on to a `close()` underlying LevelUP instance.

--- a/level-ttl.js
+++ b/level-ttl.js
@@ -145,7 +145,7 @@ function put (db, key, value, options, callback) {
 
   options = options || {};
 
-  if (default_ttl > 0 && (!options.ttl || options.ttl != 0)) {
+  if (default_ttl > 0 && !options.ttl && options.ttl != 0) {
     options.ttl = default_ttl;
   }
 
@@ -191,7 +191,7 @@ function batch (db, arr, options, callback) {
 
   options = options || {}
 
-  if (default_ttl > 0 && (!options.ttl || options.ttl != 0)) {
+  if (default_ttl > 0 && !options.ttl && options.ttl != 0) {
     options.ttl = default_ttl;
   }
 

--- a/level-ttl.js
+++ b/level-ttl.js
@@ -138,11 +138,6 @@ function ttloff (db, keys, callback) {
 
 function put (db, key, value, options, callback) {
 
-  if (typeof options == 'function') {
-    callback = options;
-    options = {};
-  }
-
   options = options || {};
 
   if (default_ttl > 0 && (!options.ttl || options.ttl != 0)) {
@@ -183,11 +178,6 @@ function del (db, key, options, callback) {
 }
 
 function batch (db, arr, options, callback) {
-
-  if (typeof options == 'function') {
-    callback = options;
-    options = {};
-  }
 
   options = options || {}
 

--- a/level-ttl.js
+++ b/level-ttl.js
@@ -145,10 +145,6 @@ function put (db, key, value, options, callback) {
 
   options = options || {};
 
-  /*if ((typeof options.ttl == 'undefined' && default_ttl > 0)
-      || (typeof options.ttl != 'undefined' && options.ttl != 0 && default_ttl > 0)) {
-    options.ttl = default_ttl;
-  }*/
   if (default_ttl > 0 && (!options.ttl || options.ttl != 0)) {
     options.ttl = default_ttl;
   }
@@ -192,6 +188,8 @@ function batch (db, arr, options, callback) {
     callback = options;
     options = {};
   }
+
+  options = options || {}
 
   if (default_ttl > 0 && (!options.ttl || options.ttl != 0)) {
     options.ttl = default_ttl;

--- a/level-ttl.js
+++ b/level-ttl.js
@@ -138,6 +138,11 @@ function ttloff (db, keys, callback) {
 
 function put (db, key, value, options, callback) {
 
+  if (typeof options == 'function') {
+    callback = options;
+    options = {};
+  }
+
   options = options || {};
 
   if (default_ttl > 0 && (!options.ttl || options.ttl != 0)) {
@@ -178,6 +183,11 @@ function del (db, key, options, callback) {
 }
 
 function batch (db, arr, options, callback) {
+
+  if (typeof options == 'function') {
+    callback = options;
+    options = {};
+  }
 
   options = options || {}
 

--- a/test.js
+++ b/test.js
@@ -193,7 +193,7 @@ ltest('test multiple ttl entries with batch-put', function (db, t, createReadStr
 
 ltest('test prolong entry life with additional put', function (db, t, createReadStream) {
   var putBar = function () {
-        db.put('bar', 'barvalue', { ttl: 100 })
+        db.put('bar', 'barvalue', { ttl: 150 })
         return Date.now()
       }
     , verify = function (base, delay) {
@@ -218,7 +218,7 @@ ltest('test prolong entry life with additional put', function (db, t, createRead
     , retest = function (delay) {
         setTimeout(function () {
           var base = putBar()
-          verify(base, 50)
+          verify(base, 75)
         }, delay)
       }
     , i
@@ -226,13 +226,13 @@ ltest('test prolong entry life with additional put', function (db, t, createRead
   db.put('foo', 'foovalue')
   for (i = 0; i < 200; i += 20)
     retest(i)
-  setTimeout(t.end.bind(t), 300)
+  setTimeout(t.end.bind(t), 500)
 })
 
 
 ltest('test prolong entry life with ttl(key, ttl)', function (db, t, createReadStream) {
   var ttlBar = function () {
-        db.ttl('bar', 100)
+        db.ttl('bar', 150)
         return Date.now()
       }
     , verify = function (base, delay) {
@@ -257,7 +257,7 @@ ltest('test prolong entry life with ttl(key, ttl)', function (db, t, createReadS
     , retest = function (delay) {
         setTimeout(function () {
           var base = ttlBar()
-          verify(base, 50)
+          verify(base, 75)
         }, delay)
       }
     , i
@@ -266,7 +266,7 @@ ltest('test prolong entry life with ttl(key, ttl)', function (db, t, createReadS
   db.put('bar', 'barvalue')
   for (i = 0; i < 200; i += 20)
     retest(i)
-  setTimeout(t.end.bind(t), 300)
+  setTimeout(t.end.bind(t), 500)
 })
 
 ltest('test del', function (db, t, createReadStream) {

--- a/test.js
+++ b/test.js
@@ -406,6 +406,35 @@ test('test stop() method stops interval and doesn\'t hold process up', function 
   })
 })
 
+test('with default ttl option', function (t) {
+  t.plan(6);
+
+  var location = '__ttl-' + Math.random()
+    , db
+
+  levelup(location, function (err, _db) {
+    t.notOk(err, 'no error on open()')
+    close = _db.close.bind(_db) // unmolested close()
+
+    db = ttl(_db, { checkFrequency: 50, defaultTTL: 10 })
+    
+    db.put( 'foo', 'bar1')
+    setTimeout(function () {
+      db.get('foo', function (err, value) {
+        t.notOk(err, 'no error')
+        t.equal('bar1', value)
+      })
+    }, 10)
+    setTimeout(function () {
+      db.get('foo', function (err, value) {
+        t.ok(err, 'got error')
+        t.ok(err.notFound, 'not found error')
+        t.notOk(value, 'no value')
+      })
+    }, 60)
+  });
+})
+
 test('without options', function (t) {
   var location = '__ttl-' + Math.random()
     , db

--- a/test.js
+++ b/test.js
@@ -136,9 +136,9 @@ ltest('test multiple ttl entries with put', function (db, t, createReadStream) {
   db.put('bar3', 'barvalue3', { ttl: 60 })
 
   expect(20, 3)
-  expect(110, 2)
-  expect(160, 1)
-  expect(210, 0)
+  expect(140, 2)
+  expect(190, 1)
+  expect(230, 0)
 
   setTimeout(t.end.bind(t), 275)
 })
@@ -193,7 +193,7 @@ ltest('test multiple ttl entries with batch-put', function (db, t, createReadStr
 
 ltest('test prolong entry life with additional put', function (db, t, createReadStream) {
   var putBar = function () {
-        db.put('bar', 'barvalue', { ttl: 40 })
+        db.put('bar', 'barvalue', { ttl: 100 })
         return Date.now()
       }
     , verify = function (base, delay) {
@@ -218,7 +218,7 @@ ltest('test prolong entry life with additional put', function (db, t, createRead
     , retest = function (delay) {
         setTimeout(function () {
           var base = putBar()
-          verify(base, 10)
+          verify(base, 50)
         }, delay)
       }
     , i
@@ -232,7 +232,7 @@ ltest('test prolong entry life with additional put', function (db, t, createRead
 
 ltest('test prolong entry life with ttl(key, ttl)', function (db, t, createReadStream) {
   var ttlBar = function () {
-        db.ttl('bar', 40)
+        db.ttl('bar', 100)
         return Date.now()
       }
     , verify = function (base, delay) {
@@ -257,7 +257,7 @@ ltest('test prolong entry life with ttl(key, ttl)', function (db, t, createReadS
     , retest = function (delay) {
         setTimeout(function () {
           var base = ttlBar()
-          verify(base, 10)
+          verify(base, 50)
         }, delay)
       }
     , i


### PR DESCRIPTION
This introduces support for a default TTL.

* Provides the ability to specify a default TTL
* If TTL is provided on put/batch, default TTL will not be used.
* If TTL is set to zero on put and batch with a defaultTTL configured, no TTL for that key will be created, allowing the key to be persisted.